### PR TITLE
Add thorough reporting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ pytest [...]
 # `test-results/report-1735941218.338192.xml` will be created
 ```
 
+### Thorough JUnit report files
+
+`pytest-nm-releng` can append some flags that will make the generated JUnit report files more thorough/comprehensive:
+
+- All output will be included in the reported (including stdout/stderr like logging)
+- All typical results/output will be included for passing tests (normally this is only captured for failing/etc. tests)
+
+> ![NOTE]
+> This does _not_ append any flags to actually generate reports. This must be done manually or with the [Dynamically-named JUnit report files](#dynamically-named-junit-report-files) feature.
+
+To enable this feature, set the `NMRE_JUNIT_FULL` env var to `1`:
+
+```shell
+# example: prefixing a command
+NMRE_JUNIT_FULL=1 pytest [...]
+```
+
 ### Code coverage
 
 `pytest-nm-releng` can automatically add some code coverage flags as well (requires [pytest-cov]).

--- a/src/pytest_nm_releng/plugin.py
+++ b/src/pytest_nm_releng/plugin.py
@@ -34,6 +34,13 @@ def generate_junit_flags() -> list[str]:
     return [f"--junit-xml={junitxml_file.as_posix()}"]
 
 
+def generate_full_junit_flags() -> list[str]:
+    if os.environ.get("NMRE_JUNIT_FULL", "") == "1":
+        return ["-o", "junit_logging=all", "-o", "junit_log_passing_tests=True"]
+
+    return []
+
+
 def generate_coverage_flags() -> list[str]:
     if not (cc_package_name := os.getenv("NMRE_COV_NAME")):
         return []
@@ -49,5 +56,6 @@ def generate_coverage_flags() -> list[str]:
 def pytest_load_initial_conftests(early_config, args: list[str], parser):
     new_args: list[str] = []
     new_args.extend(generate_junit_flags())
+    new_args.extend(generate_full_junit_flags())
     new_args.extend(generate_coverage_flags())
     args[:] = [*args, *new_args]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,11 @@ from typing import Union
 
 import pytest
 
-from pytest_nm_releng.plugin import generate_coverage_flags, generate_junit_flags
+from pytest_nm_releng.plugin import (
+    generate_coverage_flags,
+    generate_full_junit_flags,
+    generate_junit_flags,
+)
 from tests.utils import setenv
 
 EnvVarValue = Union[str, None]
@@ -48,6 +52,35 @@ def test_generate_coverage_flags_set(
         ]
 
     result = generate_coverage_flags()
+    assert result == expected_flags
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("vllm", id="value:vllm"),
+        pytest.param("", id="empty"),
+        pytest.param("1", id="1"),
+        pytest.param("0", id="0"),
+        pytest.param("2", id="2"),
+        pytest.param("-1", id="-1"),
+        pytest.param(None, id="unset"),
+    ],
+)
+def test_generate_full_junit_flags(monkeypatch: pytest.MonkeyPatch, value: EnvVarValue):
+    setenv(monkeypatch, "NMRE_JUNIT_FULL", value)
+
+    if value == "1":
+        expected_flags = [
+            "-o",
+            "junit_logging=all",
+            "-o",
+            "junit_log_passing_tests=True",
+        ]
+    else:
+        expected_flags = []
+
+    result = generate_full_junit_flags()
     assert result == expected_flags
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist = py39,py310,py311,py312
 
 [testenv]
 deps =
-    pytest >= 8
+    pytest ~= 8.3
+    pytest-cov ~= 6.0
 commands =
     pytest {posargs:tests}
 


### PR DESCRIPTION
Add a feature to improve the thoroughness of JUnit reports generated:
* Feature is enabled by setting the `NMRE_JUNIT_FULL` to `1`
* When enabled, it will configure the JUnit reports to include all captured test output (e.g., stdout and stderr channels) as well as include all of this information for passing tests (normally, it is only captured for failing tests)
* When enabled, this does _not_ set any other flags such as to create the report files, that must be done separately either manually or with other features from this plugin

Related changes:
* The README is updated with details about the new feature
* New tests are added/existing tests modified to include coverage for the new feature