### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A pytest plugin offering various functionality for Neural Magic’s Release Engi
 The Python package can be installed directly from this git repository from either a branch or tag:
 
 ```shell
-# recommended: use a version tag (e.g., v0.1.0)
-pip install https://github.com/neuralmagic/pytest-nm-releng/archive/v0.1.0.tar.gz
+# recommended: use a version tag (e.g., v0.2.0)
+pip install https://github.com/neuralmagic/pytest-nm-releng/archive/v0.2.0.tar.gz
 
 # alternative: install based on a branch (e.g., main)
 pip install https://github.com/neuralmagic/pytest-nm-releng/archive/main.tar.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytest-nm-releng"
 description = "A pytest plugin providing custom functionality for the Neural Magic release engineering team."
-version = "0.1.0"
+version = "0.2.0"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [{ name = "Domenic Barbuzzi", email = "domenic@neuralmagic.com" }]


### PR DESCRIPTION
Bumps version identifiers to `0.2.0`; to be tagged as `v0.2.0` upon merge.