### PR TITLE
Add UUID suffix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ pytest [...]
 # `test-results/1735941024.348248.xml` will be created
 ```
 
-Optionally, you can define `NMRE_JUNIT_PREFIX` with a value to be prefixed onto the file name. Note that no separator is used so you may want to include one.
+#### Additional options
+
+##### Filename prefix
+
+An environment variable named `NMRE_JUNIT_PREFIX` can be defined with a value to be prefixed onto the file name. Note that no separator is used so you may want to include one.
 
 ```shell
 export NMRE_JUNIT_BASE=test-results
@@ -49,6 +53,20 @@ pytest [...]
 
 # after either example, a file named something like
 # `test-results/report-1735941218.338192.xml` will be created
+```
+
+##### Filename suffix types
+
+An environment variable named `NMRE_JUNIT_SUFFIX_TYPE` can be defined to control what type of suffix is used. Valid values are `timestamp` (default), `uuid4`, and `uuid7`.
+
+```shell
+export NMRE_JUNIT_BASE=test-results
+export NMRE_JUNIT_PREFIX="report-"
+export NMRE_JUNIT_SUFFIX_TYPE=uuid4
+pytest [...]
+
+# after either example, a file named something like
+# `test-results/report-ffe95fcc-b818-4aca-a350-e0a35b9de6ec.xml` will be created
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "pytest>=8",
+    "uuid-utils>=0.10.0",
 ]
 
 [project.urls]

--- a/src/pytest_nm_releng/plugin.py
+++ b/src/pytest_nm_releng/plugin.py
@@ -54,12 +54,10 @@ def generate_junit_flags() -> list[str]:
         else SuffixType.TIMESTAMP
     )
 
+    prefix = os.getenv("NMRE_JUNIT_PREFIX", "")
     junitxml_file = (
-        Path(junitxml_base_dir) / f"{generate_suffix(junit_suffix_type)}.xml"
+        Path(junitxml_base_dir) / f"{prefix}{generate_suffix(junit_suffix_type)}.xml"
     )
-
-    if prefix := os.getenv("NMRE_JUNIT_PREFIX"):
-        junitxml_file = junitxml_file.with_name(f"{prefix}{junitxml_file.name}")
 
     return [f"--junit-xml={junitxml_file}"]
 

--- a/src/pytest_nm_releng/plugin.py
+++ b/src/pytest_nm_releng/plugin.py
@@ -14,6 +14,7 @@
 
 
 import os
+import warnings
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -47,12 +48,18 @@ def generate_junit_flags() -> list[str]:
     if not (junitxml_base_dir := os.getenv("NMRE_JUNIT_BASE")):
         return []
 
-    junit_suffix_type = os.getenv("NMRE_JUNIT_SUFFIX_TYPE", DEFAULT_SUFFIX_TYPE)
-    junit_suffix_type = (
-        SuffixType(junit_suffix_type)
-        if junit_suffix_type in SuffixType._value2member_map_
-        else SuffixType.TIMESTAMP
-    )
+    valid_suffix_types = [st.value for st in SuffixType]
+    junit_suffix_type = os.getenv("NMRE_JUNIT_SUFFIX_TYPE", DEFAULT_SUFFIX_TYPE.value)
+    if junit_suffix_type in valid_suffix_types:
+        junit_suffix_type = SuffixType(junit_suffix_type)
+    else:
+        msg = (
+            "NMRE_JUNIT_SUFFIX_TYPE must be one of "
+            f"{', '.join(valid_suffix_types)}, got '{junit_suffix_type}'."
+            f" Defaulting to '{DEFAULT_SUFFIX_TYPE.value}'."
+        )
+        warnings.warn(msg, UserWarning)
+        junit_suffix_type = DEFAULT_SUFFIX_TYPE
 
     prefix = os.getenv("NMRE_JUNIT_PREFIX", "")
     junitxml_file = (

--- a/src/pytest_nm_releng/plugin.py
+++ b/src/pytest_nm_releng/plugin.py
@@ -27,6 +27,9 @@ class SuffixType(Enum):
     UUID7 = "uuid7"
 
 
+DEFAULT_SUFFIX_TYPE = SuffixType.TIMESTAMP
+
+
 def get_utc_timestamp() -> str:
     return str(datetime.now(timezone.utc).timestamp())
 
@@ -44,7 +47,7 @@ def generate_junit_flags() -> list[str]:
     if not (junitxml_base_dir := os.getenv("NMRE_JUNIT_BASE")):
         return []
 
-    junit_suffix_type = os.getenv("NMRE_JUNIT_SUFFIX_TYPE")
+    junit_suffix_type = os.getenv("NMRE_JUNIT_SUFFIX_TYPE", DEFAULT_SUFFIX_TYPE)
     junit_suffix_type = (
         SuffixType(junit_suffix_type)
         if junit_suffix_type in SuffixType._value2member_map_

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,7 @@ from typing import Union
 
 import pytest
 
-from pytest_nm_releng.plugin import generate_junit_flags
+from pytest_nm_releng.plugin import DEFAULT_SUFFIX_TYPE, generate_junit_flags
 from tests.utils import setenv
 
 EnvVarValue = Union[str, None]
@@ -28,16 +28,16 @@ SUFFIX_PATTERN_MAP = {
     "uuid4": r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.xml",
     "uuid7": r"[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.xml",
 }
-DEFAULT_SUFFIX_PATTERN = SUFFIX_PATTERN_MAP["timestamp"]
+DEFAULT_SUFFIX_PATTERN = SUFFIX_PATTERN_MAP[DEFAULT_SUFFIX_TYPE.value]
 
 
 @pytest.mark.parametrize(
     ("env_junit_base", "env_junit_prefix", "env_junit_suffix"),
     [
         # base path present
-        pytest.param("test-results", "run-", "", id="base-with-prefix"),
-        pytest.param("test-results", "", "", id="base-with-empty-prefix"),
-        pytest.param("test-results", None, "", id="base-with-unset-prefix"),
+        pytest.param("test-results", "run-", None, id="base-with-prefix"),
+        pytest.param("test-results", "", None, id="base-with-empty-prefix"),
+        pytest.param("test-results", None, None, id="base-with-unset-prefix"),
         # base path empty
         pytest.param("", "run-", "", id="empty-base-with-prefix"),
         pytest.param("", "", "", id="empty-base-with-empty-prefix"),
@@ -46,10 +46,10 @@ DEFAULT_SUFFIX_PATTERN = SUFFIX_PATTERN_MAP["timestamp"]
         pytest.param(None, "run-", "", id="unset-base-with-prefix"),
         pytest.param(None, "", "", id="unset-base-with-empty-prefix"),
         pytest.param(None, None, "", id="unset-base-with-unset-prefix"),
-        # suffix empty/unset
+        # suffix empty/unset should use default
         pytest.param("test-results", "", None, id="unset-suffix-type"),
         pytest.param("test-results", "", "", id="empty-suffix-type"),
-        # suffix type variants
+        # suffix type explicitly set
         pytest.param("test-results", "", "timestamp", id="suffix-timestamp"),
         pytest.param("test-results", "", "uuid4", id="suffix-uuid4"),
         pytest.param("test-results", "", "uuid7", id="suffix-uuid7"),

--- a/tests/test_nm_releng.py
+++ b/tests/test_nm_releng.py
@@ -47,5 +47,5 @@ def test_plugin_adds_junit_args(
 
     cf = pytester.parseconfigure()
     actual = cf.getoption("--junit-xml", None)
-    assert actual is not None
+    assert isinstance(actual, str)
     assert actual.startswith("results")


### PR DESCRIPTION
Add support for UUID-based suffixes (UUID4 or UUID7). The default is still timestamp (open to discussion). There is one very light dependency added because UUID7 is not available in the Python stdlib.