### PR TITLE
Add feature to insert JUnit report properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,38 @@ pytest [...]
 # `test-results/report-ffe95fcc-b818-4aca-a350-e0a35b9de6ec.xml` will be created
 ```
 
+### Adding testsuite/testcase properties
+
+The plugin adds two optional CLI flags, `--testsuite-property` and `--testcase-property`, which provide a means to adding properties to the testsuite and testcase JUnit elements respectively.
+
+Both flags accept multiple arguments and use the same format: `name=value`. Each passed argument is split on the _first_ `=` character, so any additional characters in an individual arg will be part of the value. For example, `opts=gpu=h100` would result in a property with name `opts` and value `gpu=h100`.
+
+> [!NOTE]
+> Arguments passed to the `--testcase-property` flag will be added as properties to _all_ test cases in the run.
+
+> [!IMPORTANT]
+> Because these flags accept multiple arguments, they must be added **after** any positional args. It is okay to include them before other flags.
+
+#### Example: Adding testsuite properties
+
+```shell
+pytest [...] --testsuite-property gpu=h100
+# adds a property to the testsuite element with name 'gpu' and value 'h100'
+pytest [...] --testsuite-property gpu_name=h100 gpu_count=2
+# adds two properties to the testsuite element: one with name=gpu_name/value=h100
+# and one with name=gpu_count/value=2
+```
+
+#### Example: Adding testcase properties
+
+```shell
+pytest [...] --testcase-property gpu=h100
+# adds a property to all testcase elements with name 'gpu' and value 'h100'
+pytest [...] --testcase-property gpu_name=h100 gpu_count=2
+# adds two properties to all testcase elements: one with
+# name=gpu_name/value=h100 and one with name=gpu_count/value=2
+```
+
 ## Contributing
 
 To contribute, follow these general steps:

--- a/src/pytest_nm_releng/lib.py
+++ b/src/pytest_nm_releng/lib.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import warnings
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+
+from uuid_utils import uuid4, uuid7
+
+
+class SuffixType(Enum):
+    TIMESTAMP = "timestamp"
+    UUID4 = "uuid4"
+    UUID7 = "uuid7"
+
+
+DEFAULT_SUFFIX_TYPE = SuffixType.TIMESTAMP
+
+
+def get_utc_timestamp() -> str:
+    return str(datetime.now(timezone.utc).timestamp())
+
+
+def generate_suffix(suffix_type: SuffixType) -> str:
+    suffix_map = {
+        SuffixType.TIMESTAMP: get_utc_timestamp,
+        SuffixType.UUID4: lambda: str(uuid4()),
+        SuffixType.UUID7: lambda: str(uuid7()),
+    }
+    return suffix_map.get(suffix_type, get_utc_timestamp)()
+
+
+def generate_junit_flags() -> list[str]:
+    if not (junitxml_base_dir := os.getenv("NMRE_JUNIT_BASE")):
+        return []
+
+    valid_suffix_types = [st.value for st in SuffixType]
+    junit_suffix_type = os.getenv("NMRE_JUNIT_SUFFIX_TYPE", DEFAULT_SUFFIX_TYPE.value)
+    if junit_suffix_type in valid_suffix_types:
+        junit_suffix_type = SuffixType(junit_suffix_type)
+    else:
+        msg = (
+            "NMRE_JUNIT_SUFFIX_TYPE must be one of "
+            f"{', '.join(valid_suffix_types)}, got '{junit_suffix_type}'."
+            f" Defaulting to '{DEFAULT_SUFFIX_TYPE.value}'."
+        )
+        warnings.warn(msg, UserWarning)
+        junit_suffix_type = DEFAULT_SUFFIX_TYPE
+
+    prefix = os.getenv("NMRE_JUNIT_PREFIX", "")
+    junitxml_file = (
+        Path(junitxml_base_dir) / f"{prefix}{generate_suffix(junit_suffix_type)}.xml"
+    )
+
+    return [f"--junit-xml={junitxml_file}"]

--- a/src/pytest_nm_releng/plugin.py
+++ b/src/pytest_nm_releng/plugin.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable
+
+import pytest
+
 from .lib import generate_junit_flags
 
 
@@ -19,3 +23,44 @@ def pytest_load_initial_conftests(early_config, args: list[str], parser):
     new_args: list[str] = []
     new_args.extend(generate_junit_flags())
     args[:] = [*args, *new_args]
+
+
+# add CLI options to pass properties for test cases/suites
+def pytest_addoption(parser: pytest.Parser, pluginmanager):
+    parser.addoption(
+        "--testcase-property",
+        dest="testcase_property",
+        nargs="*",
+        help="property to add to all test cases (can pass multiple separated values)",
+    )
+    parser.addoption(
+        "--testsuite-property",
+        dest="testsuite_property",
+        nargs="*",
+        help="property to add to test suite (can pass multiple separated values)",
+    )
+
+
+# use pytest hook to add properties to testcase
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+):
+    if not (properties := config.getoption("testcase_property")):
+        return
+    for item in items:
+        for property in properties:
+            name, val = property.split("=", maxsplit=1)
+            item.user_properties.append((name, val))
+
+
+# use fixture to add properties to testsuite
+@pytest.fixture(autouse=True, scope="session")
+def add_testsuite_property(
+    request: pytest.FixtureRequest,
+    record_testsuite_property: Callable[[str, object], None],
+):
+    if not (suite_properties := request.config.getoption("testsuite_property")):
+        return
+    for property in suite_properties:
+        name, value = property.split("=", maxsplit=1)
+        record_testsuite_property(name, value)

--- a/src/pytest_nm_releng/plugin.py
+++ b/src/pytest_nm_releng/plugin.py
@@ -12,61 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import os
-import warnings
-from datetime import datetime, timezone
-from enum import Enum
-from pathlib import Path
-
-from uuid_utils import uuid4, uuid7
-
-
-class SuffixType(Enum):
-    TIMESTAMP = "timestamp"
-    UUID4 = "uuid4"
-    UUID7 = "uuid7"
-
-
-DEFAULT_SUFFIX_TYPE = SuffixType.TIMESTAMP
-
-
-def get_utc_timestamp() -> str:
-    return str(datetime.now(timezone.utc).timestamp())
-
-
-def generate_suffix(suffix_type: SuffixType) -> str:
-    suffix_map = {
-        SuffixType.TIMESTAMP: get_utc_timestamp,
-        SuffixType.UUID4: lambda: str(uuid4()),
-        SuffixType.UUID7: lambda: str(uuid7()),
-    }
-    return suffix_map.get(suffix_type, get_utc_timestamp)()
-
-
-def generate_junit_flags() -> list[str]:
-    if not (junitxml_base_dir := os.getenv("NMRE_JUNIT_BASE")):
-        return []
-
-    valid_suffix_types = [st.value for st in SuffixType]
-    junit_suffix_type = os.getenv("NMRE_JUNIT_SUFFIX_TYPE", DEFAULT_SUFFIX_TYPE.value)
-    if junit_suffix_type in valid_suffix_types:
-        junit_suffix_type = SuffixType(junit_suffix_type)
-    else:
-        msg = (
-            "NMRE_JUNIT_SUFFIX_TYPE must be one of "
-            f"{', '.join(valid_suffix_types)}, got '{junit_suffix_type}'."
-            f" Defaulting to '{DEFAULT_SUFFIX_TYPE.value}'."
-        )
-        warnings.warn(msg, UserWarning)
-        junit_suffix_type = DEFAULT_SUFFIX_TYPE
-
-    prefix = os.getenv("NMRE_JUNIT_PREFIX", "")
-    junitxml_file = (
-        Path(junitxml_base_dir) / f"{prefix}{generate_suffix(junit_suffix_type)}.xml"
-    )
-
-    return [f"--junit-xml={junitxml_file}"]
+from .lib import generate_junit_flags
 
 
 def pytest_load_initial_conftests(early_config, args: list[str], parser):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,7 @@ from typing import Union
 
 import pytest
 
-from pytest_nm_releng.plugin import DEFAULT_SUFFIX_TYPE, generate_junit_flags
+from pytest_nm_releng.lib import DEFAULT_SUFFIX_TYPE, generate_junit_flags
 from tests.utils import setenv
 
 EnvVarValue = Union[str, None]

--- a/tests/test_nm_releng.py
+++ b/tests/test_nm_releng.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import os
-import re
 from importlib.metadata import version
-from pathlib import Path
 from xml.dom import minidom
 
 import pytest

--- a/tests/test_nm_releng.py
+++ b/tests/test_nm_releng.py
@@ -13,15 +13,9 @@
 # limitations under the License.
 
 
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
 import pytest
-
-try:
-    version("pytest-cov")
-    _pytest_cov_installed = True
-except PackageNotFoundError:
-    _pytest_cov_installed = False
 
 
 def test_plugin_loaded(pytester: pytest.Pytester):

--- a/tests/test_nm_releng.py
+++ b/tests/test_nm_releng.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import re
 from importlib.metadata import version
+from pathlib import Path
 from xml.dom import minidom
 
 import pytest
@@ -39,11 +40,33 @@ def test_plugin_adds_junit_args(
     """Verify the plugin adds the expected junit args"""
 
     monkeypatch.setenv("NMRE_JUNIT_BASE", "results")
+    monkeypatch.setenv("NMRE_JUNIT_PREFIX", "report-")
 
+    # parse pytest configuration and make sure it sets the flag
     cf = pytester.parseconfigure()
-    actual = cf.getoption("--junit-xml", None)
+    actual = cf.getoption("--junit-xml")
     assert isinstance(actual, str)
     assert actual.startswith("results")
+
+    # run pytest and make sure it generates an XML file
+    pytester.makepyfile("""
+        def test_pass():
+            pass
+    """)
+    result = pytester.runpytest()
+    assert "generated xml file:" in result.stdout.str()
+
+    # make sure the generated XML file is named correctly and exists
+    pattern = re.compile(r"generated xml file: (.*?(?:\.xml))")
+    match = pattern.search(result.stdout.str())
+    assert match is not None
+    xml_file = Path(match[1])
+    assert xml_file.exists()
+    assert xml_file.parent.name == "results"
+    assert xml_file.name.startswith("report-")
+    assert re.compile(r"\d{10,}\.\d+\.xml").fullmatch(
+        xml_file.name.removeprefix("report-")
+    )
 
 
 @pytest.mark.parametrize("properties", [["courses=3"], ["courses=3", "dessert=true"]])

--- a/tests/test_nm_releng.py
+++ b/tests/test_nm_releng.py
@@ -69,7 +69,10 @@ def test_plugin_adds_junit_args(
     )
 
 
-@pytest.mark.parametrize("properties", [["courses=3"], ["courses=3", "dessert=true"]])
+@pytest.mark.parametrize(
+    "properties",
+    [["courses=3"], ["courses=3", "dessert=true"], ["courses=dessert=ice-cream"]],
+)
 def test_plugin_adds_case_properties(
     pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch, properties: list[str]
 ):
@@ -107,7 +110,10 @@ def test_plugin_adds_case_properties(
         assert sorted(props) == sorted(properties)
 
 
-@pytest.mark.parametrize("properties", [["courses=3"], ["courses=3", "dessert=true"]])
+@pytest.mark.parametrize(
+    "properties",
+    [["courses=3"], ["courses=3", "dessert=true"], ["courses=dessert=ice-cream"]],
+)
 def test_plugin_adds_suite_properties(
     pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch, properties: list[str]
 ):


### PR DESCRIPTION
These changes add a feature to insert properties into both the `testcase` and `testsuite` elements in the generated JUnit report file. As noted in the update documentation (README), these are both controlled via CLI flags: `--testcase-property` and `--testsuite-property`. Each flag is purely optional and accepts one or more property definitions in the structure `name=value`.

During the course of these changes, I made some other minor improvements:
* Refactored helper functions into a separate file to keep the main `plugin.py` file to the essentials
* Cleaned up some vestigial code in a test file that was missed when removing the non-functional features
* Augmented the plugin’s original test to be much more thorough, testing that the generated report file exists and has an expected name